### PR TITLE
feat: implement full CRUD for tasks via Firestore

### DIFF
--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { db } from "../lib/firebase";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  doc,
+  updateDoc,
+  deleteDoc,
+  onSnapshot,
+} from "firebase/firestore";
+import type { Task } from "../types/Task";
+
+const tasksRef = collection(db, "tasks");
+
+export function useTasks() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    const unsub = onSnapshot(tasksRef, (snapshot) => {
+      setTasks(snapshot.docs.map((d) => ({ ...d.data(), id: d.id })) as Task[]);
+    });
+    return unsub;
+  }, []);
+
+  const addTask = (title: string) => addDoc(tasksRef, { title, completed: false });
+  const toggleTask = (id: string, completed: boolean) =>
+    updateDoc(doc(db, "tasks", id), { completed });
+  const deleteTask = (id: string) => deleteDoc(doc(db, "tasks", id));
+
+  return { tasks, addTask, toggleTask, deleteTask };
+}

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -1,0 +1,5 @@
+export interface Task {
+  id: string;
+  title: string;
+  completed: boolean;
+}


### PR DESCRIPTION
- `useTasks` hook handles Firestore logic
- Tasks auto-update in real time
- Toggle and delete integrated

Closes #6
